### PR TITLE
feat(completion): add `showCompletion` option

### DIFF
--- a/packages/autocomplete-core/completion.ts
+++ b/packages/autocomplete-core/completion.ts
@@ -13,7 +13,12 @@ export function getCompletion<TItem>({
   state,
   props,
 }: GetCompletionProps<TItem>): string | null {
-  if (!props.showCompletion || !state.isOpen || state.status === 'stalled') {
+  if (
+    !props.showCompletion ||
+    state.highlightedIndex < 0 ||
+    !state.isOpen ||
+    state.status === 'stalled'
+  ) {
     return null;
   }
 

--- a/packages/autocomplete-core/completion.ts
+++ b/packages/autocomplete-core/completion.ts
@@ -1,0 +1,52 @@
+import { AutocompleteState, RequiredAutocompleteOptions } from './types';
+import {
+  getSuggestionFromHighlightedIndex,
+  getRelativeHighlightedIndex,
+} from './utils';
+
+interface GetCompletionProps<TItem> {
+  state: AutocompleteState<TItem>;
+  props: RequiredAutocompleteOptions<TItem>;
+}
+
+export function getCompletion<TItem>({
+  state,
+  props,
+}: GetCompletionProps<TItem>): string | null {
+  if (!props.showCompletion || !state.isOpen || state.status === 'stalled') {
+    return null;
+  }
+
+  const suggestion = getSuggestionFromHighlightedIndex({ state });
+  const item =
+    suggestion.items[getRelativeHighlightedIndex({ state, suggestion })];
+  const inputValue = suggestion.source.getInputValue({
+    suggestion: item,
+    state,
+  });
+
+  // The completion should appear only if the _first_ characters of the query
+  // match with the suggestion.
+  if (
+    state.query.length > 0 &&
+    inputValue.toLocaleLowerCase().indexOf(state.query.toLocaleLowerCase()) ===
+      0
+  ) {
+    // If the query typed has a different case than the suggestion, we want
+    // to show the completion matching the case of the query. This makes both
+    // strings overlap correctly.
+    // Example:
+    //  - query: 'Gui'
+    //  - suggestion: 'guitar'
+    //  => completion: 'Guitar'
+    const completion = state.query + inputValue.slice(state.query.length);
+
+    if (completion === state.query) {
+      return null;
+    }
+
+    return completion;
+  }
+
+  return null;
+}

--- a/packages/autocomplete-core/index.ts
+++ b/packages/autocomplete-core/index.ts
@@ -2,6 +2,7 @@ import { getDefaultProps } from './defaultProps';
 import { createStore } from './store';
 import { getPropGetters } from './propGetters';
 import { getAutocompleteSetters } from './autocompleteSetters';
+import { getCompletion } from './completion';
 
 import { AutocompleteOptions, AutocompleteInstance } from './types';
 
@@ -50,6 +51,7 @@ function createAutocomplete<TItem extends {}>(
     getItemProps,
     getLabelProps,
     getMenuProps,
+    getCompletion: () => getCompletion({ state: store.getState(), props }),
   };
 }
 

--- a/packages/autocomplete-core/onKeyDown.ts
+++ b/packages/autocomplete-core/onKeyDown.ts
@@ -1,5 +1,6 @@
 import { stateReducer } from './stateReducer';
 import { onInput } from './onInput';
+import { getCompletion } from './completion';
 import {
   getSuggestionFromHighlightedIndex,
   getRelativeHighlightedIndex,
@@ -49,6 +50,35 @@ export function onKeyDown<TItem>({
       `${props.id}-item-${store.getState().highlightedIndex}`
     );
     nodeItem?.scrollIntoView(false);
+  } else if (
+    (event.key === 'Tab' ||
+      // When the user hits the right arrow and is at the end of the input
+      // query, we validate the completion.
+      (event.key === 'ArrowRight' &&
+        (event.target as HTMLInputElement).selectionStart ===
+          store.getState().query.length)) &&
+    props.showCompletion &&
+    store.getState().isOpen
+  ) {
+    event.preventDefault();
+
+    const query = getCompletion({ state: store.getState(), props });
+
+    if (query) {
+      onInput({
+        query,
+        store,
+        props,
+        setHighlightedIndex,
+        setQuery,
+        setSuggestions,
+        setIsOpen,
+        setStatus,
+        setContext,
+      });
+
+      props.onStateChange({ state: store.getState() });
+    }
   } else if (event.key === 'Escape') {
     // This prevents the default browser behavior on `input[type="search"]`
     // to remove the query right away because we first want to close the

--- a/packages/autocomplete-core/types.ts
+++ b/packages/autocomplete-core/types.ts
@@ -131,7 +131,9 @@ export interface AutocompleteState<TItem> {
 
 export interface AutocompleteInstance<TItem>
   extends AutocompleteSetters<TItem>,
-    AutocompleteAccessibilityGetters<TItem> {}
+    AutocompleteAccessibilityGetters<TItem> {
+  getCompletion(): string | null;
+}
 
 export interface AutocompleteSourceOptions<TItem> {
   /**

--- a/packages/autocomplete-react/Autocomplete.tsx
+++ b/packages/autocomplete-react/Autocomplete.tsx
@@ -13,10 +13,12 @@ import { SearchBox } from './SearchBox';
 import { Dropdown } from './Dropdown';
 
 export function Autocomplete<TItem extends {}>(
-  props: AutocompleteOptions<TItem>
+  providedProps: AutocompleteOptions<TItem>
 ) {
-  const { initialState } = getDefaultProps(props);
-  const [state, setState] = useState<AutocompleteState<TItem>>(initialState);
+  const props = getDefaultProps(providedProps);
+  const [state, setState] = useState<AutocompleteState<TItem>>(
+    props.initialState
+  );
 
   const autocomplete = useRef(
     createAutocomplete<TItem>({
@@ -47,11 +49,11 @@ export function Autocomplete<TItem extends {}>(
       <SearchBox
         placeholder={props.placeholder}
         onInputRef={inputRef}
-        completion=""
         query={state.query}
         isOpen={state.isOpen}
         status={state.status}
         getInputProps={autocomplete.current.getInputProps}
+        completion={autocomplete.current.getCompletion()}
         onReset={event => {
           const { onReset } = autocomplete.current.getResetProps();
           onReset(event);

--- a/packages/autocomplete-react/SearchBox.tsx
+++ b/packages/autocomplete-react/SearchBox.tsx
@@ -3,8 +3,8 @@
 import { h, Ref } from 'preact';
 
 export interface SearchBoxProps {
-  completion: string;
   placeholder: string;
+  completion: string | null;
   isOpen: boolean;
   status: string;
   query: string;
@@ -15,10 +15,6 @@ export interface SearchBoxProps {
 }
 
 export function SearchBox(props: SearchBoxProps) {
-  const showCompletion = Boolean(
-    props.isOpen && props.status !== 'stalled' && props.completion
-  );
-
   return (
     <form
       action=""
@@ -67,7 +63,7 @@ export function SearchBox(props: SearchBoxProps) {
       </div>
 
       <div className="algolia-autocomplete-searchbox">
-        {showCompletion && (
+        {props.completion && (
           <span
             className="algolia-autocomplete-completion"
             aria-live={'assertive'}

--- a/stories/react.stories.tsx
+++ b/stories/react.stories.tsx
@@ -19,6 +19,7 @@ storiesOf('React', module).add(
     render(
       <Autocomplete
         placeholder="Search items…"
+        showCompletion={true}
         getSources={() => {
           return [
             {


### PR DESCRIPTION
This PR adds the completion feature with the option `showCompletion`.

## Feature

- The completion is available for the highlighted item
- "Tab" / "Right arrow positioned at the end" triggers the completion

## API

The autocomplete instance returns a new function: `getCompletion`. Renderers can use it to display the hint (see React renderer).

## Preview

![autocomplete-completion](https://user-images.githubusercontent.com/6137112/74155859-89508080-4c15-11ea-963d-5d055f546a2f.gif)
