### PR TITLE
feat: introduce `defaultHighlightedIndex`

### DIFF
--- a/packages/autocomplete-core/defaultProps.ts
+++ b/packages/autocomplete-core/defaultProps.ts
@@ -18,6 +18,7 @@ export function getDefaultProps<TItem>(
     id: generateAutocompleteId(),
     minLength: 1,
     placeholder: '',
+    defaultHighlightedIndex: 0,
     showCompletion: false,
     stallThreshold: 300,
     environment,

--- a/packages/autocomplete-core/onInput.ts
+++ b/packages/autocomplete-core/onInput.ts
@@ -37,7 +37,7 @@ export function onInput<TItem>({
     clearTimeout(lastStalledId);
   }
 
-  setHighlightedIndex(0);
+  setHighlightedIndex(props.defaultHighlightedIndex);
   setQuery(query);
 
   if (query.length < props.minLength) {

--- a/packages/autocomplete-core/propGetters.ts
+++ b/packages/autocomplete-core/propGetters.ts
@@ -220,6 +220,19 @@ export function getPropGetters({
       role: 'listbox',
       'aria-labelledby': `${props.id}-label`,
       id: `${props.id}-menu`,
+      onMouseLeave() {
+        store.setState(
+          stateReducer(
+            store.getState(),
+            {
+              type: 'mouseleave',
+              value: null,
+            },
+            props
+          )
+        );
+        props.onStateChange({ state: store.getState() });
+      },
       ...rest,
     };
   };

--- a/packages/autocomplete-core/stateReducer.ts
+++ b/packages/autocomplete-core/stateReducer.ts
@@ -16,6 +16,7 @@ type ActionType =
   | 'reset'
   | 'focus'
   | 'mousemove'
+  | 'mouseleave'
   | 'click'
   | 'blur';
 
@@ -117,8 +118,7 @@ export const stateReducer = <TItem>(
     case 'reset': {
       return {
         ...state,
-        // @TODO: fallback to default value
-        highlightedIndex: -1,
+        highlightedIndex: props.defaultHighlightedIndex,
         isOpen: false,
         status: 'idle',
         statusContext: {},
@@ -129,7 +129,7 @@ export const stateReducer = <TItem>(
     case 'focus': {
       return {
         ...state,
-        highlightedIndex: 0,
+        highlightedIndex: props.defaultHighlightedIndex,
         isOpen: state.query.length >= props.minLength,
       };
     }
@@ -148,6 +148,13 @@ export const stateReducer = <TItem>(
       return {
         ...state,
         highlightedIndex: action.value,
+      };
+    }
+
+    case 'mouseleave': {
+      return {
+        ...state,
+        highlightedIndex: props.defaultHighlightedIndex,
       };
     }
 

--- a/packages/autocomplete-core/stateReducer.ts
+++ b/packages/autocomplete-core/stateReducer.ts
@@ -118,7 +118,7 @@ export const stateReducer = <TItem>(
     case 'reset': {
       return {
         ...state,
-        highlightedIndex: props.defaultHighlightedIndex,
+        highlightedIndex: -1,
         isOpen: false,
         status: 'idle',
         statusContext: {},

--- a/packages/autocomplete-core/types.ts
+++ b/packages/autocomplete-core/types.ts
@@ -224,6 +224,12 @@ export interface AutocompleteOptions<TItem> {
    */
   placeholder?: string;
   /**
+   * The default item index to pre-select.
+   *
+   * @default 0
+   */
+  defaultHighlightedIndex?: number;
+  /**
    * The function called when an item is selected.
    */
   // onSelect(): void;
@@ -287,6 +293,7 @@ export interface RequiredAutocompleteOptions<TItem> {
   id: string;
   onStateChange<TItem>(props: { state: AutocompleteState<TItem> }): void;
   placeholder: string;
+  defaultHighlightedIndex: number;
   showCompletion: boolean;
   minLength: number;
   stallThreshold: number;

--- a/stories/react.stories.tsx
+++ b/stories/react.stories.tsx
@@ -20,6 +20,7 @@ storiesOf('React', module).add(
       <Autocomplete
         placeholder="Search items…"
         showCompletion={true}
+        defaultHighlightedIndex={-1}
         getSources={() => {
           return [
             {


### PR DESCRIPTION
This PR adds the `defaultHighlightedIndex` option.

It also adds a coupled feature that resets `state.highlightedIndex` when the menu receives the `mouseleave` event. This pattern is used on Google and Amazon.

You can use the value `-1` to not select anything by default (same value as Downshift uses).

## Different use cases

### Hits

> This is the use case for DocSearch or the Algolia Documentation website.

When displaying hits, you want to highlight the first hit by default so that the user can directly hit "Enter" and get directed to the link.

### Query Suggestions

> This is the use case for the Query Suggestions pattern in InstantSearch.

When displaying query suggestions, you don't want to highlight the first query suggestion because hitting "Enter" shouldn't select the first entry, but rather trigger the search. Otherwise, user is blocked and can only select suggestions, not their actual search.

## Preview

![autocomplete-mouseleave](https://user-images.githubusercontent.com/6137112/74160452-b99c1d00-4c1d-11ea-8850-d06ba0693086.gif)
