### PR TITLE
feat: open menu on input click

### DIFF
--- a/packages/autocomplete-core/propGetters.ts
+++ b/packages/autocomplete-core/propGetters.ts
@@ -34,6 +34,29 @@ export function getPropGetters({
   };
 
   const getInputProps: GetInputProps = rest => {
+    function onFocus() {
+      // We want to trigger a query when `minLength` is reached because the
+      // dropdown should open with the current query.
+      if (store.getState().query.length >= props.minLength) {
+        onInput({
+          query: store.getState().query,
+          store,
+          props,
+          setHighlightedIndex,
+          setQuery,
+          setSuggestions,
+          setIsOpen,
+          setStatus,
+          setContext,
+        });
+      }
+
+      store.setState(
+        stateReducer(store.getState(), { type: 'focus', value: {} }, props)
+      );
+      props.onStateChange({ state: store.getState() });
+    }
+
     return {
       'aria-autocomplete': 'list',
       'aria-activedescendant':
@@ -78,29 +101,8 @@ export function getPropGetters({
           setContext,
         });
       },
-      onFocus() {
-        // We want to trigger a query when `minLength` is reached because the
-        // dropdown should open with the current query.
-        if (store.getState().query.length >= props.minLength) {
-          onInput({
-            query: store.getState().query,
-            store,
-            props,
-            setHighlightedIndex,
-            setQuery,
-            setSuggestions,
-            setIsOpen,
-            setStatus,
-            setContext,
-          });
-        }
-
-        store.setState(
-          stateReducer(store.getState(), { type: 'focus', value: {} }, props)
-        );
-        props.onStateChange({ state: store.getState() });
-      },
-      onBlur() {
+      onFocus,
+      onBlur: () => {
         store.setState(
           stateReducer(
             store.getState(),
@@ -112,6 +114,18 @@ export function getPropGetters({
           )
         );
         props.onStateChange({ state: store.getState() });
+      },
+      onClick: () => {
+        // When the dropdown is closed and you click on the input while
+        // the input is focused, the `onFocus` event is not triggered
+        // (default browser behavior).
+        // In an autocomplete context, it makes sense to open the menu in this
+        // case.
+        // We mimic this event by catching the `onClick` event which
+        // triggers the `onFocus` for the dropdown to open.
+        if (!store.getState().isOpen) {
+          onFocus();
+        }
       },
       ...rest,
     };

--- a/packages/autocomplete-core/propGetters.ts
+++ b/packages/autocomplete-core/propGetters.ts
@@ -123,7 +123,11 @@ export function getPropGetters({
         // case.
         // We mimic this event by catching the `onClick` event which
         // triggers the `onFocus` for the dropdown to open.
-        if (!store.getState().isOpen) {
+        if (
+          rest.inputElement === props.environment.document.activeElement &&
+          !store.getState().isOpen &&
+          store.getState().query.length >= props.minLength
+        ) {
           onFocus();
         }
       },

--- a/packages/autocomplete-core/types.ts
+++ b/packages/autocomplete-core/types.ts
@@ -36,8 +36,9 @@ export type GetRootProps = (props?: {
   'aria-labelledby': string;
 };
 
-export type GetInputProps = (props?: {
+export type GetInputProps = (props: {
   [key: string]: unknown;
+  inputElement: HTMLInputElement;
 }) => {
   id: string;
   value: string;

--- a/packages/autocomplete-core/types.ts
+++ b/packages/autocomplete-core/types.ts
@@ -55,6 +55,7 @@ export type GetInputProps = (props?: {
   onKeyDown(event: KeyboardEvent): void;
   onFocus(): void;
   onBlur(): void;
+  onClick(event: MouseEvent): void;
 };
 
 export type GetResetProps = (props?: {

--- a/packages/autocomplete-react/SearchBox.tsx
+++ b/packages/autocomplete-react/SearchBox.tsx
@@ -82,15 +82,6 @@ export function SearchBox(props: SearchBoxProps) {
             placeholder: props.placeholder,
             type: 'search',
             maxLength: '512',
-            // When the dropdown is closed and you click on the input while
-            // the input is focused, the `onFocus` event is not triggered.
-            // We mimic this event by catching the `onClick` event which
-            // triggers the `onFocus` for the dropdown to open.
-            // onClick: () => {
-            //   if (!props.isOpen) {
-            //     props.onFocus();
-            //   }
-            // },
           })}
         />
       </div>

--- a/packages/autocomplete-react/SearchBox.tsx
+++ b/packages/autocomplete-react/SearchBox.tsx
@@ -79,6 +79,7 @@ export function SearchBox(props: SearchBoxProps) {
           className="algolia-autocomplete-input"
           {...props.getInputProps({
             ref: props.onInputRef,
+            inputElement: (props.onInputRef as any).current,
             placeholder: props.placeholder,
             type: 'search',
             maxLength: '512',


### PR DESCRIPTION
When the dropdown is closed and you click on the input while the input is focused, the `onFocus` event is not triggered (default browser behavior).

In an autocomplete context, it makes sense to open the menu in this case.

We mimic this event by catching the `onClick` event which triggers the `onFocus` for the dropdown to open.