### PR TITLE
feat: introduce `getFormProps`

### DIFF
--- a/packages/autocomplete-core/index.ts
+++ b/packages/autocomplete-core/index.ts
@@ -22,8 +22,8 @@ function createAutocomplete<TItem extends {}>(
   } = getAutocompleteSetters({ store, props });
   const {
     getRootProps,
+    getFormProps,
     getInputProps,
-    getResetProps,
     getItemProps,
     getLabelProps,
     getMenuProps,
@@ -46,8 +46,8 @@ function createAutocomplete<TItem extends {}>(
     setStatus,
     setContext,
     getRootProps,
+    getFormProps,
     getInputProps,
-    getResetProps,
     getItemProps,
     getLabelProps,
     getMenuProps,

--- a/packages/autocomplete-core/onKeyDown.ts
+++ b/packages/autocomplete-core/onKeyDown.ts
@@ -97,9 +97,6 @@ export function onKeyDown<TItem>({
     );
     props.onStateChange({ state: store.getState() });
   } else if (event.key === 'Enter') {
-    // This prevents the `onSubmit` event to be sent.
-    event.preventDefault();
-
     if (store.getState().highlightedIndex < 0) {
       return;
     }
@@ -112,6 +109,12 @@ export function onKeyDown<TItem>({
       suggestion.items[
         getRelativeHighlightedIndex({ state: store.getState(), suggestion })
       ];
+
+    if (item) {
+      // This prevents the `onSubmit` event to be sent when an item is selected.
+      event.preventDefault();
+    }
+
     const itemUrl = suggestion.source.getSuggestionUrl({
       suggestion: item,
       state: store.getState(),

--- a/packages/autocomplete-core/propGetters.ts
+++ b/packages/autocomplete-core/propGetters.ts
@@ -5,8 +5,8 @@ import { isSpecialClick } from './utils';
 
 import {
   GetRootProps,
+  GetFormProps,
   GetInputProps,
-  GetResetProps,
   GetItemProps,
   GetLabelProps,
   GetMenuProps,
@@ -29,6 +29,44 @@ export function getPropGetters({
       'aria-haspopup': 'listbox',
       'aria-owns': store.getState().isOpen ? `${props.id}-menu` : null,
       'aria-labelledby': `${props.id}-label`,
+      ...rest,
+    };
+  };
+
+  const getFormProps: GetFormProps = rest => {
+    return {
+      onSubmit: event => {
+        event.preventDefault();
+
+        // @TODO: call the `onInputChange` or `onSubmit` user prop?
+
+        store.setState(
+          stateReducer(store.getState(), { type: 'submit', value: null }, props)
+        );
+        props.onStateChange({ state: store.getState() });
+      },
+      onReset: event => {
+        event.preventDefault();
+
+        if (props.minLength === 0) {
+          onInput({
+            query: '',
+            store,
+            props,
+            setHighlightedIndex,
+            setQuery,
+            setSuggestions,
+            setIsOpen,
+            setStatus,
+            setContext,
+          });
+        }
+
+        store.setState(
+          stateReducer(store.getState(), { type: 'reset', value: {} }, props)
+        );
+        props.onStateChange({ state: store.getState() });
+      },
       ...rest,
     };
   };
@@ -135,34 +173,6 @@ export function getPropGetters({
     };
   };
 
-  const getResetProps: GetResetProps = rest => {
-    return {
-      onReset(event) {
-        event.preventDefault();
-
-        if (props.minLength === 0) {
-          onInput({
-            query: '',
-            store,
-            props,
-            setHighlightedIndex,
-            setQuery,
-            setSuggestions,
-            setIsOpen,
-            setStatus,
-            setContext,
-          });
-        }
-
-        store.setState(
-          stateReducer(store.getState(), { type: 'reset', value: {} }, props)
-        );
-        props.onStateChange({ state: store.getState() });
-      },
-      ...rest,
-    };
-  };
-
   const getItemProps: GetItemProps<any> = rest => {
     if (rest.item === undefined) {
       throw new Error('`getItemProps` expects an `item`.');
@@ -257,8 +267,8 @@ export function getPropGetters({
 
   return {
     getRootProps,
+    getFormProps,
     getInputProps,
-    getResetProps,
     getItemProps,
     getLabelProps,
     getMenuProps,

--- a/packages/autocomplete-core/propGetters.ts
+++ b/packages/autocomplete-core/propGetters.ts
@@ -44,6 +44,10 @@ export function getPropGetters({
           stateReducer(store.getState(), { type: 'submit', value: null }, props)
         );
         props.onStateChange({ state: store.getState() });
+
+        if (rest?.inputElement) {
+          rest.inputElement.blur();
+        }
       },
       onReset: event => {
         event.preventDefault();
@@ -66,6 +70,10 @@ export function getPropGetters({
           stateReducer(store.getState(), { type: 'reset', value: {} }, props)
         );
         props.onStateChange({ state: store.getState() });
+
+        if (rest?.inputElement) {
+          rest.inputElement.focus();
+        }
       },
       ...rest,
     };
@@ -162,7 +170,7 @@ export function getPropGetters({
         // We mimic this event by catching the `onClick` event which
         // triggers the `onFocus` for the dropdown to open.
         if (
-          rest.inputElement === props.environment.document.activeElement &&
+          rest?.inputElement === props.environment.document.activeElement &&
           !store.getState().isOpen &&
           store.getState().query.length >= props.minLength
         ) {

--- a/packages/autocomplete-core/stateReducer.ts
+++ b/packages/autocomplete-core/stateReducer.ts
@@ -13,6 +13,7 @@ type ActionType =
   | 'ArrowDown'
   | 'Escape'
   | 'Enter'
+  | 'submit'
   | 'reset'
   | 'focus'
   | 'mousemove'
@@ -112,6 +113,16 @@ export const stateReducer = <TItem>(
         status: 'idle',
         statusContext: {},
         suggestions: [],
+      };
+    }
+
+    case 'submit': {
+      return {
+        ...state,
+        highlightedIndex: -1,
+        isOpen: false,
+        status: 'idle',
+        statusContext: {},
       };
     }
 

--- a/packages/autocomplete-core/types.ts
+++ b/packages/autocomplete-core/types.ts
@@ -36,6 +36,13 @@ export type GetRootProps = (props?: {
   'aria-labelledby': string;
 };
 
+export type GetFormProps = (props?: {
+  [key: string]: unknown;
+}) => {
+  onSubmit(event: Event): void;
+  onReset(event: Event): void;
+};
+
 export type GetInputProps = (props: {
   [key: string]: unknown;
   inputElement: HTMLInputElement;
@@ -57,12 +64,6 @@ export type GetInputProps = (props: {
   onFocus(): void;
   onBlur(): void;
   onClick(event: MouseEvent): void;
-};
-
-export type GetResetProps = (props?: {
-  [key: string]: unknown;
-}) => {
-  onReset(event: Event): void;
 };
 
 export type GetItemProps<TItem> = (props: {
@@ -111,8 +112,8 @@ export interface Suggestion<TItem> {
 
 export interface AutocompleteAccessibilityGetters<TItem> {
   getRootProps: GetRootProps;
+  getFormProps: GetFormProps;
   getInputProps: GetInputProps;
-  getResetProps: GetResetProps;
   getItemProps: GetItemProps<TItem>;
   getLabelProps: GetLabelProps;
   getMenuProps: GetMenuProps;

--- a/packages/autocomplete-core/types.ts
+++ b/packages/autocomplete-core/types.ts
@@ -36,14 +36,15 @@ export type GetRootProps = (props?: {
   'aria-labelledby': string;
 };
 
-export type GetFormProps = (props?: {
+export type GetFormProps = (props: {
   [key: string]: unknown;
+  inputElement: HTMLInputElement | null;
 }) => {
   onSubmit(event: Event): void;
   onReset(event: Event): void;
 };
 
-export type GetInputProps = (props: {
+export type GetInputProps = (props?: {
   [key: string]: unknown;
   inputElement: HTMLInputElement;
 }) => {

--- a/packages/autocomplete-react/Autocomplete.tsx
+++ b/packages/autocomplete-react/Autocomplete.tsx
@@ -54,22 +54,9 @@ export function Autocomplete<TItem extends {}>(
         status={state.status}
         getInputProps={autocomplete.current.getInputProps}
         completion={autocomplete.current.getCompletion()}
-        onReset={event => {
-          const { onReset } = autocomplete.current.getFormProps();
-          onReset(event);
-
-          if (inputRef.current) {
-            inputRef.current.focus();
-          }
-        }}
-        onSubmit={event => {
-          const { onSubmit } = autocomplete.current.getFormProps();
-          onSubmit(event);
-
-          if (inputRef.current) {
-            inputRef.current.blur();
-          }
-        }}
+        {...autocomplete.current.getFormProps({
+          inputElement: inputRef.current,
+        })}
       />
 
       <Dropdown

--- a/packages/autocomplete-react/Autocomplete.tsx
+++ b/packages/autocomplete-react/Autocomplete.tsx
@@ -55,14 +55,21 @@ export function Autocomplete<TItem extends {}>(
         getInputProps={autocomplete.current.getInputProps}
         completion={autocomplete.current.getCompletion()}
         onReset={event => {
-          const { onReset } = autocomplete.current.getResetProps();
+          const { onReset } = autocomplete.current.getFormProps();
           onReset(event);
 
           if (inputRef.current) {
             inputRef.current.focus();
           }
         }}
-        onSubmit={() => {}}
+        onSubmit={event => {
+          const { onSubmit } = autocomplete.current.getFormProps();
+          onSubmit(event);
+
+          if (inputRef.current) {
+            inputRef.current.blur();
+          }
+        }}
       />
 
       <Dropdown

--- a/packages/autocomplete-react/SearchBox.tsx
+++ b/packages/autocomplete-react/SearchBox.tsx
@@ -24,6 +24,7 @@ export function SearchBox(props: SearchBoxProps) {
       noValidate
       className="algolia-autocomplete-form"
       onSubmit={props.onSubmit}
+      onReset={props.onReset}
     >
       <label
         htmlFor={props.getInputProps().id}


### PR DESCRIPTION
This removes the getter prop `getResetProps` and moves its `onReset` prop to `getFormProps`. We now handle the reset and submit cases in the core library itself.