### PR TITLE
feat: handle input focus events in `getFormProps`

### DIFF
--- a/packages/autocomplete-core/propGetters.ts
+++ b/packages/autocomplete-core/propGetters.ts
@@ -44,6 +44,10 @@ export function getPropGetters({
           stateReducer(store.getState(), { type: 'submit', value: null }, props)
         );
         props.onStateChange({ state: store.getState() });
+
+        if (rest?.inputElement) {
+          rest.inputElement.blur();
+        }
       },
       onReset: event => {
         event.preventDefault();
@@ -66,6 +70,10 @@ export function getPropGetters({
           stateReducer(store.getState(), { type: 'reset', value: {} }, props)
         );
         props.onStateChange({ state: store.getState() });
+
+        if (rest?.inputElement) {
+          rest.inputElement.focus();
+        }
       },
       ...rest,
     };
@@ -162,7 +170,7 @@ export function getPropGetters({
         // We mimic this event by catching the `onClick` event which
         // triggers the `onFocus` for the dropdown to open.
         if (
-          rest.inputElement === props.environment.document.activeElement &&
+          rest?.inputElement === props.environment.document.activeElement &&
           !store.getState().isOpen &&
           store.getState().query.length >= props.minLength
         ) {

--- a/packages/autocomplete-core/types.ts
+++ b/packages/autocomplete-core/types.ts
@@ -36,8 +36,9 @@ export type GetRootProps = (props?: {
   'aria-labelledby': string;
 };
 
-export type GetFormProps = (props?: {
+export type GetFormProps = (props: {
   [key: string]: unknown;
+  inputElement: HTMLInputElement;
 }) => {
   onSubmit(event: Event): void;
   onReset(event: Event): void;

--- a/packages/autocomplete-core/types.ts
+++ b/packages/autocomplete-core/types.ts
@@ -38,13 +38,13 @@ export type GetRootProps = (props?: {
 
 export type GetFormProps = (props: {
   [key: string]: unknown;
-  inputElement: HTMLInputElement;
+  inputElement: HTMLInputElement | null;
 }) => {
   onSubmit(event: Event): void;
   onReset(event: Event): void;
 };
 
-export type GetInputProps = (props: {
+export type GetInputProps = (props?: {
   [key: string]: unknown;
   inputElement: HTMLInputElement;
 }) => {

--- a/packages/autocomplete-react/Autocomplete.tsx
+++ b/packages/autocomplete-react/Autocomplete.tsx
@@ -54,22 +54,9 @@ export function Autocomplete<TItem extends {}>(
         status={state.status}
         getInputProps={autocomplete.current.getInputProps}
         completion={autocomplete.current.getCompletion()}
-        onReset={event => {
-          const { onReset } = autocomplete.current.getFormProps();
-          onReset(event);
-
-          if (inputRef.current) {
-            inputRef.current.focus();
-          }
-        }}
-        onSubmit={event => {
-          const { onSubmit } = autocomplete.current.getFormProps();
-          onSubmit(event);
-
-          if (inputRef.current) {
-            inputRef.current.blur();
-          }
-        }}
+        {...autocomplete.current.getFormProps({
+          inputElement: inputRef.current,
+        })}
       />
 
       <Dropdown

--- a/packages/autocomplete-react/SearchBox.tsx
+++ b/packages/autocomplete-react/SearchBox.tsx
@@ -24,6 +24,7 @@ export function SearchBox(props: SearchBoxProps) {
       noValidate
       className="algolia-autocomplete-form"
       onSubmit={props.onSubmit}
+      onReset={props.onReset}
     >
       <label
         htmlFor={props.getInputProps().id}


### PR DESCRIPTION
This simplifies how the form props are passed to the renderer so that they don't have to implement the focus and blur states of the input element.