### PR TITLE
feat(onError): introduce `onError` option

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,5 +27,6 @@ module.exports = {
     '@typescript-eslint/camelcase': ['error', { allow: ['__autocomplete_id'] }],
     // Useful to call functions like `nodeItem?.scrollIntoView()`.
     'no-unused-expressions': 0,
+    complexity: 0,
   },
 };

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ This function is also called when the input is clicked while already having the 
 
 #### `onError`
 
-> `(options: { state: AutocompleteState, ...setters }) => void` | defaults to `({ state }) => throw state.error`
+> `(options: { state: AutocompleteState, ...setters }) => void` | defaults to `({ state }) => { throw state.contextStatus.error }`
 
 Called when an error is thrown while getting the suggestions.
 

--- a/packages/autocomplete-core/autocompleteSetters.ts
+++ b/packages/autocomplete-core/autocompleteSetters.ts
@@ -67,6 +67,15 @@ export function getAutocompleteSetters<TItem>({
     props.onStateChange({ state: store.getState() });
   };
 
+  const setStatusContext: AutocompleteInstance<
+    TItem
+  >['setStatusContext'] = value => {
+    store.setState(
+      stateReducer(store.getState(), { type: 'setStatusContext', value }, props)
+    );
+    props.onStateChange({ state: store.getState() });
+  };
+
   const setContext: AutocompleteInstance<TItem>['setContext'] = value => {
     store.setState(
       stateReducer(store.getState(), { type: 'setContext', value }, props)
@@ -80,6 +89,7 @@ export function getAutocompleteSetters<TItem>({
     setSuggestions,
     setIsOpen,
     setStatus,
+    setStatusContext,
     setContext,
   };
 }

--- a/packages/autocomplete-core/defaultProps.ts
+++ b/packages/autocomplete-core/defaultProps.ts
@@ -25,6 +25,9 @@ export function getDefaultProps<TItem>(
     environment,
     shouldDropdownOpen: ({ state }) => getItemsCount(state) > 0,
     onStateChange: noop,
+    onError: ({ state }) => {
+      throw state.statusContext.error;
+    },
     ...props,
     // The following props need to be deeply defaulted.
     initialState: {
@@ -33,7 +36,7 @@ export function getDefaultProps<TItem>(
       suggestions: [],
       isOpen: false,
       status: 'idle',
-      statusContext: {},
+      statusContext: { error: null },
       context: {},
       ...props.initialState,
     },

--- a/packages/autocomplete-core/index.ts
+++ b/packages/autocomplete-core/index.ts
@@ -18,6 +18,7 @@ function createAutocomplete<TItem extends {}>(
     setSuggestions,
     setIsOpen,
     setStatus,
+    setStatusContext,
     setContext,
   } = getAutocompleteSetters({ store, props });
   const {
@@ -35,6 +36,7 @@ function createAutocomplete<TItem extends {}>(
     setSuggestions,
     setIsOpen,
     setStatus,
+    setStatusContext,
     setContext,
   });
 
@@ -44,6 +46,7 @@ function createAutocomplete<TItem extends {}>(
     setSuggestions,
     setIsOpen,
     setStatus,
+    setStatusContext,
     setContext,
     getRootProps,
     getFormProps,

--- a/packages/autocomplete-core/onInput.ts
+++ b/packages/autocomplete-core/onInput.ts
@@ -3,6 +3,7 @@ import {
   AutocompleteSetters,
   RequiredAutocompleteOptions,
   AutocompleteState,
+  ErroredAutocompleteState,
 } from './types';
 
 let lastStalledId: number | null = null;
@@ -30,6 +31,7 @@ export function onInput<TItem>({
   setSuggestions,
   setIsOpen,
   setStatus,
+  setStatusContext,
   setContext,
   nextState = {},
 }: OnInputOptions<TItem>): void {
@@ -39,6 +41,7 @@ export function onInput<TItem>({
 
   setHighlightedIndex(props.defaultHighlightedIndex);
   setQuery(query);
+  setStatusContext({ error: null });
 
   if (query.length < props.minLength) {
     setStatus('idle');
@@ -108,8 +111,18 @@ export function onInput<TItem>({
         })
         .catch(error => {
           setStatus('error');
+          setStatusContext({ error });
 
-          throw error;
+          props.onError({
+            state: store.getState() as ErroredAutocompleteState<TItem>,
+            setHighlightedIndex,
+            setQuery,
+            setSuggestions,
+            setIsOpen,
+            setStatus,
+            setStatusContext,
+            setContext,
+          });
         })
         .finally(() => {
           if (lastStalledId) {

--- a/packages/autocomplete-core/onKeyDown.ts
+++ b/packages/autocomplete-core/onKeyDown.ts
@@ -27,6 +27,7 @@ export function onKeyDown<TItem>({
   setSuggestions,
   setIsOpen,
   setStatus,
+  setStatusContext,
   setContext,
 }: OnKeyDownOptions<TItem>): void {
   if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
@@ -74,6 +75,7 @@ export function onKeyDown<TItem>({
         setSuggestions,
         setIsOpen,
         setStatus,
+        setStatusContext,
         setContext,
       });
 
@@ -152,6 +154,7 @@ export function onKeyDown<TItem>({
         setSuggestions,
         setIsOpen,
         setStatus,
+        setStatusContext,
         setContext,
         nextState: {
           isOpen: false,

--- a/packages/autocomplete-core/propGetters.ts
+++ b/packages/autocomplete-core/propGetters.ts
@@ -28,6 +28,7 @@ export function getPropGetters<TItem>({
   setSuggestions,
   setIsOpen,
   setStatus,
+  setStatusContext,
   setContext,
 }: GetPropGettersOptions<TItem>) {
   const getRootProps: GetRootProps = rest => {
@@ -70,6 +71,7 @@ export function getPropGetters<TItem>({
             setSuggestions,
             setIsOpen,
             setStatus,
+            setStatusContext,
             setContext,
           });
         }
@@ -101,6 +103,7 @@ export function getPropGetters<TItem>({
           setSuggestions,
           setIsOpen,
           setStatus,
+          setStatusContext,
           setContext,
         });
       }
@@ -139,6 +142,7 @@ export function getPropGetters<TItem>({
           setSuggestions,
           setIsOpen,
           setStatus,
+          setStatusContext,
           setContext,
         });
       },
@@ -152,6 +156,7 @@ export function getPropGetters<TItem>({
           setSuggestions,
           setIsOpen,
           setStatus,
+          setStatusContext,
           setContext,
         });
       },
@@ -239,6 +244,7 @@ export function getPropGetters<TItem>({
           setSuggestions,
           setIsOpen,
           setStatus,
+          setStatusContext,
           setContext,
           nextState: {
             isOpen: false,

--- a/packages/autocomplete-core/stateReducer.ts
+++ b/packages/autocomplete-core/stateReducer.ts
@@ -8,6 +8,7 @@ type ActionType =
   | 'setSuggestions'
   | 'setIsOpen'
   | 'setStatus'
+  | 'setStatusContext'
   | 'setContext'
   | 'ArrowUp'
   | 'ArrowDown'
@@ -67,6 +68,13 @@ export const stateReducer = <TItem>(
       };
     }
 
+    case 'setStatusContext': {
+      return {
+        ...state,
+        statusContext: action.value,
+      };
+    }
+
     case 'setContext': {
       return {
         ...state,
@@ -111,7 +119,7 @@ export const stateReducer = <TItem>(
         ...state,
         query: '',
         status: 'idle',
-        statusContext: {},
+        statusContext: { error: null },
         suggestions: [],
       };
     }
@@ -122,7 +130,7 @@ export const stateReducer = <TItem>(
         highlightedIndex: -1,
         isOpen: false,
         status: 'idle',
-        statusContext: {},
+        statusContext: { error: null },
       };
     }
 
@@ -132,7 +140,7 @@ export const stateReducer = <TItem>(
         highlightedIndex: -1,
         isOpen: false,
         status: 'idle',
-        statusContext: {},
+        statusContext: { error: null },
         query: '',
       };
     }

--- a/packages/autocomplete-core/types.ts
+++ b/packages/autocomplete-core/types.ts
@@ -99,6 +99,7 @@ export interface AutocompleteSetters<TItem> {
   setSuggestions: StateUpdater<AutocompleteState<TItem>['suggestions']>;
   setIsOpen: StateUpdater<AutocompleteState<TItem>['isOpen']>;
   setStatus: StateUpdater<AutocompleteState<TItem>['status']>;
+  setStatusContext: StateUpdater<AutocompleteState<TItem>['statusContext']>;
   setContext: StateUpdater<AutocompleteState<TItem>['context']>;
 }
 
@@ -125,9 +126,16 @@ export interface AutocompleteState<TItem> {
   isOpen: boolean;
   status: AutocompleteStatus;
   statusContext: {
-    error?: Error;
+    error: Error | null;
   };
   context: { [key: string]: unknown };
+}
+
+export interface ErroredAutocompleteState<TItem>
+  extends AutocompleteState<TItem> {
+  statusContext: {
+    error: Error;
+  };
 }
 
 export interface AutocompleteInstance<TItem>
@@ -170,8 +178,9 @@ export interface AutocompleteSourceOptions<TItem> {
   onSelect?: (options: ItemEventHandlerOptions<TItem>) => void;
 }
 
-export interface EventHandlerOptions<TItem> extends AutocompleteSetters<TItem> {
-  state: AutocompleteState<TItem>;
+export interface EventHandlerOptions<TItem, TState = AutocompleteState<TItem>>
+  extends AutocompleteSetters<TItem> {
+  state: TState;
 }
 
 export interface ItemEventHandlerOptions<TItem>
@@ -285,6 +294,12 @@ export interface AutocompleteOptions<TItem> {
    * The function called to determine whether the dropdown should open.
    */
   shouldDropdownOpen?(options: { state: AutocompleteState<TItem> }): boolean;
+  /**
+   * Function called when an error is thrown while getting the suggestions.
+   */
+  onError?(
+    options: EventHandlerOptions<TItem, ErroredAutocompleteState<TItem>>
+  ): void;
 }
 
 export type NormalizedAutocompleteSource = {
@@ -310,4 +325,7 @@ export interface RequiredAutocompleteOptions<TItem> {
   environment: Environment;
   navigator: Navigator;
   shouldDropdownOpen(options: { state: AutocompleteState<TItem> }): boolean;
+  onError(
+    options: EventHandlerOptions<TItem, ErroredAutocompleteState<TItem>>
+  ): void;
 }


### PR DESCRIPTION
> I'm not sure we should introduce this option until somebody needs it, so I only open this PR as a draft.

## Description

This adds the `onError` option to catch errors while fetching suggestions.

## Usage

```js
<Autocomplete
  onError={({ state }) => {
    console.error(state.statusContext.error.message);
  }}
  getSources={() => {
    return [
      {
        getInputValue({ suggestion }) {
          return suggestion.query;
        },
        getSuggestions({ query }) {
          return Promise.reject(new Error("Can't fetch suggestions."));
        },
      },
    ];
  }}
/>
```

## Notes

- Perhaps `onError` is too generic as a name?
- `statusContext` seems really close to `status` and `context` already present in the state object