### PR TITLE
feat(onSubmit): introduce `onSubmit` option

### DIFF
--- a/packages/autocomplete-core/defaultProps.ts
+++ b/packages/autocomplete-core/defaultProps.ts
@@ -25,6 +25,7 @@ export function getDefaultProps<TItem>(
     environment,
     shouldDropdownOpen: ({ state }) => getItemsCount(state) > 0,
     onStateChange: noop,
+    onSubmit: noop,
     ...props,
     // The following props need to be deeply defaulted.
     initialState: {

--- a/packages/autocomplete-core/propGetters.ts
+++ b/packages/autocomplete-core/propGetters.ts
@@ -46,7 +46,16 @@ export function getPropGetters<TItem>({
       onSubmit: event => {
         event.preventDefault();
 
-        // @TODO: call the `onInputChange` or `onSubmit` user prop?
+        props.onSubmit({
+          state: store.getState(),
+          setHighlightedIndex,
+          setQuery,
+          setSuggestions,
+          setIsOpen,
+          setStatus,
+          setContext,
+          event,
+        });
 
         store.setState(
           stateReducer(store.getState(), { type: 'submit', value: null }, props)

--- a/packages/autocomplete-core/types.ts
+++ b/packages/autocomplete-core/types.ts
@@ -167,15 +167,16 @@ export interface AutocompleteSourceOptions<TItem> {
   /**
    * Called when an item is selected.
    */
-  onSelect?: (options: ItemEventHandlerOptions<TItem>) => void;
+  onSelect?: (options: ItemEventHandlerParams<TItem>) => void;
 }
 
-export interface EventHandlerOptions<TItem> extends AutocompleteSetters<TItem> {
+interface EventHandlerParams<TItem> extends AutocompleteSetters<TItem> {
   state: AutocompleteState<TItem>;
+  event: Event;
 }
 
-export interface ItemEventHandlerOptions<TItem>
-  extends EventHandlerOptions<TItem> {
+export interface ItemEventHandlerParams<TItem>
+  extends EventHandlerParams<TItem> {
   suggestion: Suggestion<TItem>;
   suggestionValue: ReturnType<AutocompleteSource['getInputValue']>;
   suggestionUrl: ReturnType<AutocompleteSource['getSuggestionUrl']>;
@@ -285,6 +286,10 @@ export interface AutocompleteOptions<TItem> {
    * The function called to determine whether the dropdown should open.
    */
   shouldDropdownOpen?(options: { state: AutocompleteState<TItem> }): boolean;
+  /**
+   * The function called when the autocomplete form is submitted.
+   */
+  onSubmit?(params: EventHandlerParams<TItem>): void;
 }
 
 export type NormalizedAutocompleteSource = {
@@ -310,4 +315,5 @@ export interface RequiredAutocompleteOptions<TItem> {
   environment: Environment;
   navigator: Navigator;
   shouldDropdownOpen(options: { state: AutocompleteState<TItem> }): boolean;
+  onSubmit(params: EventHandlerParams<TItem>): void;
 }


### PR DESCRIPTION
## Description

This PR introduces the `onSubmit` option. This prop is called when the `submit` form event is triggered (not when an item is selected – subject to another PR).

## Use case

The `submit` form event is triggered when the user hits <kbd>Enter</kbd> _without_ any item selected.

In an InstantSearch context, it's the default behavior of the search box, where we would call `refine`. Note that with an InstantSearch implementation, we would also call `refine` when calling `onSelect`.