### PR TITLE
feat(core): introduce `getEnvironmentProps` for mobile experience

### DIFF
--- a/packages/autocomplete-core/src/index.ts
+++ b/packages/autocomplete-core/src/index.ts
@@ -22,6 +22,7 @@ function createAutocomplete<TItem extends {}>(
     setContext,
   } = getAutocompleteSetters({ store, props });
   const {
+    getEnvironmentProps,
     getRootProps,
     getFormProps,
     getInputProps,
@@ -46,6 +47,7 @@ function createAutocomplete<TItem extends {}>(
     setIsOpen,
     setStatus,
     setContext,
+    getEnvironmentProps,
     getRootProps,
     getFormProps,
     getInputProps,

--- a/packages/autocomplete-core/src/propGetters.ts
+++ b/packages/autocomplete-core/src/propGetters.ts
@@ -39,7 +39,7 @@ export function getPropGetters<TItem>({
       // input to close the dropdown, but rather on a custom `touchstart` event
       // outside of the autocomplete elements.
       // This ensures a working experience on mobile because we blur the input
-      // on touch devices when the user starts scrolling (`ontouchmove`).
+      // on touch devices when the user starts scrolling (`touchmove`).
       onTouchStart(event) {
         if (store.getState().isOpen === false) {
           return;
@@ -226,6 +226,8 @@ export function getPropGetters<TItem>({
       },
       onFocus,
       onBlur: () => {
+        // We do rely on the `blur` event on touch devices.
+        // See explanation in `onTouchStart`.
         if (!isTouchDevice) {
           store.setState(
             stateReducer(

--- a/packages/autocomplete-core/src/propGetters.ts
+++ b/packages/autocomplete-core/src/propGetters.ts
@@ -1,7 +1,7 @@
 import { stateReducer } from './stateReducer';
 import { onInput } from './onInput';
 import { onKeyDown } from './onKeyDown';
-import { isSpecialClick, getHighlightedItem, isOrContainsNode } from './utils';
+import { isSpecialClick, getHighlightedItem } from './utils';
 
 import {
   GetEnvironmentProps,
@@ -35,49 +35,15 @@ export function getPropGetters<TItem>({
 
   const getEnvironmentProps: GetEnvironmentProps = getterProps => {
     return {
-      mouseUp(event) {
-        // We do not rely on the native `blur` event of the input to close
-        // the dropdown, but rather on a custom `mouseup` event outside
-        // of the autocomplete elements.
-        // This ensures a working experience on mobile because we blur the input
-        // on touch devices when the user starts scrolling.
-        const isTargetWithinAutocomplete = [
-          getterProps.searchBoxElement,
-          getterProps.dropdownElement,
-        ].some(contextNode => {
-          return (
-            contextNode &&
-            (isOrContainsNode(contextNode, event.target as Node) ||
-              isOrContainsNode(
-                contextNode,
-                props.environment.document.activeElement!
-              ))
-          );
-        });
-
-        if (
-          store.getState().isOpen === true &&
-          isTargetWithinAutocomplete === false
-        ) {
-          store.setState(
-            stateReducer(
-              store.getState(),
-              {
-                type: 'outerclick',
-                value: null,
-              },
-              props
-            )
-          );
-          props.onStateChange({ state: store.getState() });
-        }
-      },
       // When scrolling on touch devices (mobiles, tablets, etc.), we want to
       // mimic the native platform behavior where the input is blurred to
       // hide the virtual keyboard. This gives more vertical space to
       // discover all the suggestions showing up in the dropdown.
-      onScroll() {
-        if (store.getState().isOpen === false) {
+      onTouchMove() {
+        if (
+          store.getState().isOpen === false ||
+          getterProps.inputElement !== props.environment.document.activeElement
+        ) {
           return;
         }
 

--- a/packages/autocomplete-core/src/stateReducer.ts
+++ b/packages/autocomplete-core/src/stateReducer.ts
@@ -19,8 +19,7 @@ type ActionType =
   | 'blur'
   | 'mousemove'
   | 'mouseleave'
-  | 'click'
-  | 'outerclick';
+  | 'click';
 
 interface Action {
   type: ActionType;
@@ -148,8 +147,7 @@ export const stateReducer = <TItem>(
       };
     }
 
-    case 'blur':
-    case 'outerclick': {
+    case 'blur': {
       return {
         ...state,
         isOpen: false,

--- a/packages/autocomplete-core/src/stateReducer.ts
+++ b/packages/autocomplete-core/src/stateReducer.ts
@@ -19,7 +19,7 @@ type ActionType =
   | 'mousemove'
   | 'mouseleave'
   | 'click'
-  | 'blur';
+  | 'outerclick';
 
 interface Action {
   type: ActionType;
@@ -147,13 +147,10 @@ export const stateReducer = <TItem>(
       };
     }
 
-    case 'blur': {
-      // In development mode, we prefer keeping the dropdown open on blur
-      // to use the browser dev tools.
+    case 'outerclick': {
       return {
         ...state,
-        isOpen: __DEV__ ? state.isOpen : false,
-        highlightedIndex: null,
+        isOpen: false,
       };
     }
 

--- a/packages/autocomplete-core/src/stateReducer.ts
+++ b/packages/autocomplete-core/src/stateReducer.ts
@@ -16,6 +16,7 @@ type ActionType =
   | 'submit'
   | 'reset'
   | 'focus'
+  | 'blur'
   | 'mousemove'
   | 'mouseleave'
   | 'click'
@@ -147,10 +148,12 @@ export const stateReducer = <TItem>(
       };
     }
 
+    case 'blur':
     case 'outerclick': {
       return {
         ...state,
         isOpen: false,
+        highlightedIndex: null,
       };
     }
 

--- a/packages/autocomplete-core/src/types/getters.ts
+++ b/packages/autocomplete-core/src/types/getters.ts
@@ -58,6 +58,7 @@ export type GetInputProps = (props: {
   onInput(event: Event): void;
   onKeyDown(event: KeyboardEvent): void;
   onFocus(): void;
+  onBlur(): void;
   onClick(event: MouseEvent): void;
 };
 

--- a/packages/autocomplete-core/src/types/getters.ts
+++ b/packages/autocomplete-core/src/types/getters.ts
@@ -16,7 +16,8 @@ export type GetEnvironmentProps = (props: {
   dropdownElement: HTMLElement;
   inputElement: HTMLInputElement;
 }) => {
-  onTouchMove(event: Event): void;
+  onTouchStart(event: TouchEvent): void;
+  onTouchMove(event: TouchEvent): void;
 };
 
 export type GetRootProps = (props?: {

--- a/packages/autocomplete-core/src/types/getters.ts
+++ b/packages/autocomplete-core/src/types/getters.ts
@@ -16,8 +16,7 @@ export type GetEnvironmentProps = (props: {
   dropdownElement: HTMLElement;
   inputElement: HTMLInputElement;
 }) => {
-  mouseUp(event: MouseEvent): void;
-  onScroll(event: Event): void;
+  onTouchMove(event: Event): void;
 };
 
 export type GetRootProps = (props?: {

--- a/packages/autocomplete-core/src/types/getters.ts
+++ b/packages/autocomplete-core/src/types/getters.ts
@@ -1,6 +1,7 @@
 import { AutocompleteSource } from './api';
 
 export interface AutocompleteAccessibilityGetters<TItem> {
+  getEnvironmentProps: GetEnvironmentProps;
   getRootProps: GetRootProps;
   getFormProps: GetFormProps;
   getInputProps: GetInputProps;
@@ -8,6 +9,16 @@ export interface AutocompleteAccessibilityGetters<TItem> {
   getLabelProps: GetLabelProps;
   getMenuProps: GetMenuProps;
 }
+
+export type GetEnvironmentProps = (props: {
+  [key: string]: unknown;
+  searchBoxElement: HTMLElement;
+  dropdownElement: HTMLElement;
+  inputElement: HTMLInputElement;
+}) => {
+  mouseUp(event: MouseEvent): void;
+  onScroll(event: Event): void;
+};
 
 export type GetRootProps = (props?: {
   [key: string]: unknown;
@@ -30,6 +41,7 @@ export type GetFormProps = (props: {
 export type GetInputProps = (props: {
   [key: string]: unknown;
   inputElement: HTMLInputElement;
+  dropdownElement: HTMLElement;
 }) => {
   id: string;
   value: string;
@@ -46,7 +58,6 @@ export type GetInputProps = (props: {
   onInput(event: Event): void;
   onKeyDown(event: KeyboardEvent): void;
   onFocus(): void;
-  onBlur(): void;
   onClick(event: MouseEvent): void;
 };
 

--- a/packages/autocomplete-core/src/utils.ts
+++ b/packages/autocomplete-core/src/utils.ts
@@ -191,7 +191,3 @@ export function getHighlightedItem<TItem>({
     source,
   };
 }
-
-export function isOrContainsNode(parent: Node, child: Node) {
-  return parent === child || (parent.contains && parent.contains(child));
-}

--- a/packages/autocomplete-core/src/utils.ts
+++ b/packages/autocomplete-core/src/utils.ts
@@ -191,3 +191,7 @@ export function getHighlightedItem<TItem>({
     source,
   };
 }
+
+export function isOrContainsNode(parent: Node, child: Node) {
+  return parent === child || (parent.contains && parent.contains(child));
+}

--- a/packages/autocomplete-react/src/Autocomplete.tsx
+++ b/packages/autocomplete-react/src/Autocomplete.tsx
@@ -76,18 +76,16 @@ export function Autocomplete<TItem extends {}>(
       return undefined;
     }
 
-    const { mouseUp, onScroll } = autocomplete.getEnvironmentProps({
+    const { onTouchMove } = autocomplete.getEnvironmentProps({
       searchBoxElement: searchBoxRef.current,
       dropdownElement: dropdownRef.current,
       inputElement: inputRef.current,
     });
 
-    props.environment.addEventListener('mouseup', mouseUp);
-    props.environment.addEventListener('scroll', onScroll);
+    props.environment.addEventListener('touchmove', onTouchMove);
 
     return () => {
-      props.environment.removeEventListener('mouseup', mouseUp);
-      props.environment.removeEventListener('scroll', onScroll);
+      props.environment.removeEventListener('touchmove', onTouchMove);
     };
   }, [autocomplete, searchBoxRef, dropdownRef, inputRef, props.environment]);
 

--- a/packages/autocomplete-react/src/Autocomplete.tsx
+++ b/packages/autocomplete-react/src/Autocomplete.tsx
@@ -76,15 +76,17 @@ export function Autocomplete<TItem extends {}>(
       return undefined;
     }
 
-    const { onTouchMove } = autocomplete.getEnvironmentProps({
+    const { onTouchStart, onTouchMove } = autocomplete.getEnvironmentProps({
       searchBoxElement: searchBoxRef.current,
       dropdownElement: dropdownRef.current,
       inputElement: inputRef.current,
     });
 
+    props.environment.addEventListener('touchstart', onTouchStart);
     props.environment.addEventListener('touchmove', onTouchMove);
 
     return () => {
+      props.environment.removeEventListener('touchstart', onTouchStart);
       props.environment.removeEventListener('touchmove', onTouchMove);
     };
   }, [autocomplete, searchBoxRef, dropdownRef, inputRef, props.environment]);

--- a/packages/autocomplete-react/src/Autocomplete.tsx
+++ b/packages/autocomplete-react/src/Autocomplete.tsx
@@ -1,7 +1,7 @@
 /** @jsx h */
 
 import { h } from 'preact';
-import { useRef } from 'preact/hooks';
+import { useRef, useEffect } from 'preact/hooks';
 import { createPortal } from 'preact/compat';
 
 import {
@@ -71,6 +71,26 @@ export function Autocomplete<TItem extends {}>(
   const [state, autocomplete] = useAutocomplete<TItem>(props);
   useDropdown<TItem>(rendererProps, state, searchBoxRef, dropdownRef);
 
+  useEffect(() => {
+    if (!(searchBoxRef.current && dropdownRef.current && inputRef.current)) {
+      return undefined;
+    }
+
+    const { mouseUp, onScroll } = autocomplete.getEnvironmentProps({
+      searchBoxElement: searchBoxRef.current,
+      dropdownElement: dropdownRef.current,
+      inputElement: inputRef.current,
+    });
+
+    props.environment.addEventListener('mouseup', mouseUp);
+    props.environment.addEventListener('scroll', onScroll);
+
+    return () => {
+      props.environment.removeEventListener('mouseup', mouseUp);
+      props.environment.removeEventListener('scroll', onScroll);
+    };
+  }, [autocomplete, searchBoxRef, dropdownRef, inputRef, props.environment]);
+
   return (
     <div
       className={[
@@ -85,6 +105,7 @@ export function Autocomplete<TItem extends {}>(
       <SearchBox
         searchBoxRef={searchBoxRef}
         inputRef={inputRef}
+        dropdownRef={dropdownRef}
         placeholder={props.placeholder}
         query={state.query}
         isOpen={state.isOpen}

--- a/packages/autocomplete-react/src/SearchBox.tsx
+++ b/packages/autocomplete-react/src/SearchBox.tsx
@@ -19,6 +19,7 @@ export interface SearchBoxProps {
   getLabelProps: GetLabelProps;
   inputRef: Ref<HTMLInputElement>;
   searchBoxRef: Ref<HTMLFormElement>;
+  dropdownRef: Ref<HTMLElement>;
 }
 
 export function SearchBox(props: SearchBoxProps) {
@@ -87,6 +88,7 @@ export function SearchBox(props: SearchBoxProps) {
           {...props.getInputProps({
             ref: props.inputRef,
             inputElement: (props.inputRef as any).current,
+            dropdownElement: (props.dropdownRef as any).current,
             type: 'search',
             maxLength: '512',
           })}

--- a/stories/react.stories.tsx
+++ b/stories/react.stories.tsx
@@ -135,4 +135,41 @@ storiesOf('React', module)
 
       return container;
     })
+  )
+  .add(
+    'Long list of items',
+    withPlayground(({ container, dropdownContainer }) => {
+      render(
+        <Autocomplete
+          placeholder="Search items…"
+          dropdownContainer={dropdownContainer}
+          getSources={() => {
+            return [
+              {
+                getInputValue({ suggestion }) {
+                  return suggestion.query;
+                },
+                getSuggestions({ query }) {
+                  return getAlgoliaHits({
+                    searchClient,
+                    queries: [
+                      {
+                        indexName: 'instant_search_demo_query_suggestions',
+                        query,
+                        params: {
+                          hitsPerPage: 40,
+                        },
+                      },
+                    ],
+                  });
+                },
+              },
+            ];
+          }}
+        />,
+        container
+      );
+
+      return container;
+    })
   );


### PR DESCRIPTION
This PR adds capabilities to replicate "native behaviors" when using an autocomplete experience on mobile.

## Inspiration

This is the wanted behavior as seen on the native Twitter app:

![twitter-search-scroll](https://user-images.githubusercontent.com/6137112/74550627-fb94ce00-4f51-11ea-94ac-07baa4fa45ba.gif)

You can notice that the virtual keyboard hides as soon as you scroll, leaving you more space to discover the results.

## API

The core library now exports another prop getter: `getEnvironmentProps` (reminder: the default environment is `window`).

This function returns two event handlers that are attached in the renderers:

### `onTouchMove`

In native mobile apps, the virtual keyboard pops up when the input is focused, but closes as soon as you start scrolling the results list.

On touch devices, this function blurs the input if the dropdown is open. This function is mapped to the native `touchstart` event so it's a noop for non-touch devices.

### `onTouchStart`

Since we now trigger the `blur` event on the `touchmove` event, we cannot rely on the `blur` event to close the menu.

We now need to attach a `touchstart` listener to the environment that closes the menu if the clicked target is not an Autocomplete element.

The dropdown is closed when you interact with an element outside of the autocomplete container.

## Preview

![autocomplete-scroll](https://user-images.githubusercontent.com/6137112/74550797-431b5a00-4f52-11ea-9894-b588715944f7.gif)

