### PR TITLE
refactor(core): subscribe `onStateChange` to store changes

### DIFF
--- a/packages/autocomplete-core/autocompleteSetters.ts
+++ b/packages/autocomplete-core/autocompleteSetters.ts
@@ -25,14 +25,12 @@ export function getAutocompleteSetters<TItem>({
         props
       )
     );
-    props.onStateChange({ state: store.getState() });
   };
 
   const setQuery: AutocompleteApi<TItem>['setQuery'] = value => {
     store.setState(
       stateReducer(store.getState(), { type: 'setQuery', value }, props)
     );
-    props.onStateChange({ state: store.getState() });
   };
 
   const setSuggestions: AutocompleteApi<TItem>['setSuggestions'] = rawValue => {
@@ -48,28 +46,24 @@ export function getAutocompleteSetters<TItem>({
     store.setState(
       stateReducer(store.getState(), { type: 'setSuggestions', value }, props)
     );
-    props.onStateChange({ state: store.getState() });
   };
 
   const setIsOpen: AutocompleteApi<TItem>['setIsOpen'] = value => {
     store.setState(
       stateReducer(store.getState(), { type: 'setIsOpen', value }, props)
     );
-    props.onStateChange({ state: store.getState() });
   };
 
   const setStatus: AutocompleteApi<TItem>['setStatus'] = value => {
     store.setState(
       stateReducer(store.getState(), { type: 'setStatus', value }, props)
     );
-    props.onStateChange({ state: store.getState() });
   };
 
   const setContext: AutocompleteApi<TItem>['setContext'] = value => {
     store.setState(
       stateReducer(store.getState(), { type: 'setContext', value }, props)
     );
-    props.onStateChange({ state: store.getState() });
   };
 
   return {

--- a/packages/autocomplete-core/index.ts
+++ b/packages/autocomplete-core/index.ts
@@ -10,7 +10,7 @@ function createAutocomplete<TItem extends {}>(
   options: PublicAutocompleteOptions<TItem>
 ): AutocompleteApi<TItem> {
   const props = getDefaultProps(options);
-  const store = createStore(props.initialState);
+  const store = createStore(props.initialState, props.onStateChange);
 
   const {
     setHighlightedIndex,

--- a/packages/autocomplete-core/onKeyDown.ts
+++ b/packages/autocomplete-core/onKeyDown.ts
@@ -41,7 +41,6 @@ export function onKeyDown<TItem>({
         props
       )
     );
-    props.onStateChange({ state: store.getState() });
 
     const nodeItem = props.environment.document.getElementById(
       `${props.id}-item-${store.getState().highlightedIndex}`
@@ -94,8 +93,6 @@ export function onKeyDown<TItem>({
         setStatus,
         setContext,
       });
-
-      props.onStateChange({ state: store.getState() });
     }
   } else if (event.key === 'Escape') {
     // This prevents the default browser behavior on `input[type="search"]`
@@ -113,7 +110,6 @@ export function onKeyDown<TItem>({
         props
       )
     );
-    props.onStateChange({ state: store.getState() });
   } else if (event.key === 'Enter') {
     // No item is selected, so we let the browser handle the native `onSubmit`
     // form event.
@@ -176,8 +172,6 @@ export function onKeyDown<TItem>({
           setContext,
           event,
         });
-
-        props.onStateChange({ state: store.getState() });
       });
 
       if (itemUrl !== undefined) {

--- a/packages/autocomplete-core/propGetters.ts
+++ b/packages/autocomplete-core/propGetters.ts
@@ -62,7 +62,6 @@ export function getPropGetters<TItem>({
         store.setState(
           stateReducer(store.getState(), { type: 'submit', value: null }, props)
         );
-        props.onStateChange({ state: store.getState() });
 
         if (providedProps.inputElement) {
           providedProps.inputElement.blur();
@@ -88,7 +87,6 @@ export function getPropGetters<TItem>({
         store.setState(
           stateReducer(store.getState(), { type: 'reset', value: {} }, props)
         );
-        props.onStateChange({ state: store.getState() });
 
         if (providedProps.inputElement) {
           providedProps.inputElement.focus();
@@ -119,7 +117,6 @@ export function getPropGetters<TItem>({
       store.setState(
         stateReducer(store.getState(), { type: 'focus', value: {} }, props)
       );
-      props.onStateChange({ state: store.getState() });
     }
 
     const { inputElement, ...rest } = providedProps;
@@ -180,7 +177,6 @@ export function getPropGetters<TItem>({
             props
           )
         );
-        props.onStateChange({ state: store.getState() });
       },
       onClick: () => {
         // When the dropdown is closed and you click on the input while
@@ -226,7 +222,6 @@ export function getPropGetters<TItem>({
             props
           )
         );
-        props.onStateChange({ state: store.getState() });
 
         if (store.getState().highlightedIndex !== null) {
           const { item, itemValue, itemUrl, source } = getHighlightedItem({
@@ -296,8 +291,6 @@ export function getPropGetters<TItem>({
             setContext,
             event,
           });
-
-          props.onStateChange({ state: store.getState() });
         });
       },
       ...rest,
@@ -328,7 +321,6 @@ export function getPropGetters<TItem>({
             props
           )
         );
-        props.onStateChange({ state: store.getState() });
       },
       ...rest,
     };

--- a/packages/autocomplete-core/store.ts
+++ b/packages/autocomplete-core/store.ts
@@ -1,7 +1,10 @@
 import { AutocompleteState, AutocompleteStore } from './types';
 
+type Listener<TItem> = (params: { state: AutocompleteState<TItem> }) => void;
+
 export function createStore<TItem>(
-  initialState: AutocompleteState<TItem>
+  initialState: AutocompleteState<TItem>,
+  listener: Listener<TItem>
 ): AutocompleteStore<TItem> {
   return {
     state: initialState,
@@ -10,6 +13,8 @@ export function createStore<TItem>(
     },
     setState(nextState) {
       this.state = nextState;
+
+      listener({ state: this.state });
     },
   };
 }


### PR DESCRIPTION
This removes all the manual calls to `props.onStateChange` and subscribe this function to the store so that it's automatically notified when the state changes.