### PR TITLE
poc: add recent searches story

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "lerna": "3.20.2",
     "preact": "10.3.1",
     "prettier": "1.19.1",
+    "recent-searches": "1.0.5",
     "rollup": "1.31.0",
     "rollup-plugin-babel": "4.3.3",
     "rollup-plugin-commonjs": "10.1.0",

--- a/packages/autocomplete-react/src/Dropdown.tsx
+++ b/packages/autocomplete-react/src/Dropdown.tsx
@@ -56,14 +56,19 @@ export const Dropdown = (props: DropdownProps) => {
                             tabIndex: 0,
                           })}
                         >
-                          <div
-                            dangerouslySetInnerHTML={{
-                              __html: reverseHighlightAlgoliaHit({
-                                hit: item,
-                                attribute: 'query',
-                              }),
-                            }}
-                          />
+                          {/* The templating API is hardcoded for now */}
+                          {item._highlightResult ? (
+                            <div
+                              dangerouslySetInnerHTML={{
+                                __html: reverseHighlightAlgoliaHit({
+                                  hit: item,
+                                  attribute: 'query',
+                                }),
+                              }}
+                            />
+                          ) : (
+                            item.query
+                          )}
                         </li>
                       );
                     })}

--- a/stories/recent.stories.tsx
+++ b/stories/recent.stories.tsx
@@ -1,0 +1,80 @@
+/** @jsx h */
+
+import { h, render } from 'preact';
+import { storiesOf } from '@storybook/html';
+import algoliasearch from 'algoliasearch/lite';
+import RecentSearches from 'recent-searches';
+
+import { Autocomplete } from '@francoischalifour/autocomplete-react';
+import { getAlgoliaHits } from '@francoischalifour/autocomplete-preset-algolia';
+import { withPlayground } from '../.storybook/decorators';
+
+const searchClient = algoliasearch(
+  'latency',
+  '6be0576ff61c053d5f9a3225e2a90f76'
+);
+
+storiesOf('Recent', module).add(
+  'Local storage',
+  withPlayground(({ container, dropdownContainer }) => {
+    const recentSearches = new RecentSearches();
+
+    render(
+      <Autocomplete
+        placeholder="Search items…"
+        minLength={0}
+        showCompletion={true}
+        dropdownContainer={dropdownContainer}
+        defaultHighlightedIndex={null}
+        onSubmit={({ state }) => {
+          recentSearches.setRecentSearch(state.query, { query: state.query });
+        }}
+        getSources={() => {
+          return [
+            {
+              getInputValue({ suggestion }) {
+                return suggestion.query;
+              },
+              getSuggestions({ query }) {
+                return recentSearches.getRecentSearches(query);
+              },
+            },
+            {
+              getInputValue({ suggestion }) {
+                return suggestion.query;
+              },
+              onSelect({ suggestion, suggestionValue }) {
+                recentSearches.setRecentSearch(suggestionValue, suggestion);
+              },
+              getSuggestions({ query }) {
+                return getAlgoliaHits({
+                  searchClient,
+                  queries: [
+                    {
+                      indexName: 'instant_search_demo_query_suggestions',
+                      query,
+                      params: {
+                        hitsPerPage: 4,
+                      },
+                    },
+                  ],
+                }).then(hits => {
+                  const recentHits = recentSearches.getRecentSearches(query);
+
+                  // Remove duplicates from the Algolia received results.
+                  return hits.filter(
+                    hit =>
+                      recentHits.map(x => x.query).indexOf(hit.query) === -1
+                  );
+                });
+              },
+            },
+          ];
+        }}
+      />,
+      container
+    );
+
+    return container;
+  })
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -11298,6 +11298,11 @@ recast@~0.11.12:
     private "~0.1.5"
     source-map "~0.5.0"
 
+recent-searches@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/recent-searches/-/recent-searches-1.0.5.tgz#4a66941c2cce0106ecf5125bbbfe74f27f61d2ac"
+  integrity sha512-qktUqEOQa5HfDXG+X+SuABmGEvz2liiF1CTg34fbV4MgdJaPdNs3XGbuaJhANANSXGlVTw8S8u5qxIuKYX7gUg==
+
 rechoir@^0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"


### PR DESCRIPTION
This PR demonstrate how to integrate recent searches with autocomplete. It uses the [Recent Searches](https://github.com/JonasBa/recent-searches) library to communicate with the local storage.

The integration is quite straightforward, but we can think about covering more cases (sync recent searches across devices via an endpoint or an Algolia index) and creating an autocomplete plugin for recent searches.