### PR TITLE
feat: add openOnFocus and remove minLength

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Whether to show the highlighted suggestion as completion in the input.
 
 > `boolean` | defaults to `false`
 
-Whether to open the dropdown on focus.
+Whether to open the dropdown on focus when there's no query.
 
 #### `autoFocus`
 

--- a/README.md
+++ b/README.md
@@ -209,11 +209,11 @@ Whether to show the highlighted suggestion as completion in the input.
 
 ![`showCompletion` preview](https://user-images.githubusercontent.com/6137112/68124812-7e989800-ff10-11e9-88a5-f28c1466b665.png)
 
-#### `minLength`
+#### `openOnFocus`
 
-> `number` | defaults to `1`
+> `boolean` | defaults to `false`
 
-The minimum number of characters long the autocomplete opens.
+Whether to open the dropdown on focus.
 
 #### `autoFocus`
 

--- a/examples/autocomplete.js/index.tsx
+++ b/examples/autocomplete.js/index.tsx
@@ -17,7 +17,7 @@ const searchClient = algoliasearch(
 autocomplete({
   container: '#autocomplete',
   placeholder: 'Search…',
-  minLength: 0,
+  openOnFocus: true,
   showCompletion: true,
   defaultHighlightedIndex: -1,
   shouldDropdownOpen({ state }) {

--- a/packages/autocomplete-core/src/defaultProps.ts
+++ b/packages/autocomplete-core/src/defaultProps.ts
@@ -15,7 +15,7 @@ export function getDefaultProps<TItem>(
     : {}) as typeof window;
 
   return {
-    minLength: 1,
+    openOnFocus: false,
     placeholder: '',
     autoFocus: false,
     defaultHighlightedIndex: null,

--- a/packages/autocomplete-core/src/onInput.ts
+++ b/packages/autocomplete-core/src/onInput.ts
@@ -55,21 +55,6 @@ export function onInput<TItem>({
   setHighlightedIndex(props.defaultHighlightedIndex);
   setQuery(query);
 
-  if (query.length < props.minLength) {
-    setStatus('idle');
-    setSuggestions(
-      store.getState().suggestions.map(suggestion => ({
-        ...suggestion,
-        items: [],
-      }))
-    );
-    setIsOpen(
-      nextState.isOpen ?? props.shouldDropdownShow({ state: store.getState() })
-    );
-
-    return Promise.resolve();
-  }
-
   setStatus('loading');
 
   lastStalledId = props.environment.setTimeout(() => {
@@ -117,7 +102,7 @@ export function onInput<TItem>({
           setSuggestions(suggestions as any);
           setIsOpen(
             nextState.isOpen ??
-              (query.length >= props.minLength &&
+              (props.openOnFocus ||
                 props.shouldDropdownShow({ state: store.getState() }))
           );
         })

--- a/packages/autocomplete-core/src/onInput.ts
+++ b/packages/autocomplete-core/src/onInput.ts
@@ -55,6 +55,21 @@ export function onInput<TItem>({
   setHighlightedIndex(props.defaultHighlightedIndex);
   setQuery(query);
 
+  if (query.length === 0 && props.openOnFocus === false) {
+    setStatus('idle');
+    setSuggestions(
+      store.getState().suggestions.map(suggestion => ({
+        ...suggestion,
+        items: [],
+      }))
+    );
+    setIsOpen(
+      nextState.isOpen ?? props.shouldDropdownShow({ state: store.getState() })
+    );
+
+    return Promise.resolve();
+  }
+
   setStatus('loading');
 
   lastStalledId = props.environment.setTimeout(() => {

--- a/packages/autocomplete-core/src/onInput.ts
+++ b/packages/autocomplete-core/src/onInput.ts
@@ -117,7 +117,7 @@ export function onInput<TItem>({
           setSuggestions(suggestions as any);
           setIsOpen(
             nextState.isOpen ??
-              (props.openOnFocus ||
+              ((query.length === 0 && props.openOnFocus) ||
                 props.shouldDropdownShow({ state: store.getState() }))
           );
         })

--- a/packages/autocomplete-core/src/propGetters.ts
+++ b/packages/autocomplete-core/src/propGetters.ts
@@ -226,8 +226,7 @@ export function getPropGetters<TItem>({
         if (
           providedProps.inputElement ===
             props.environment.document.activeElement &&
-          !store.getState().isOpen &&
-          (props.openOnFocus || store.getState().query.length > 0)
+          !store.getState().isOpen
         ) {
           onFocus();
         }

--- a/packages/autocomplete-core/src/propGetters.ts
+++ b/packages/autocomplete-core/src/propGetters.ts
@@ -144,7 +144,7 @@ export function getPropGetters<TItem>({
     function onFocus() {
       // We want to trigger a query when `openOnFocus` is true
       // because the dropdown should open with the current query.
-      if (props.openOnFocus) {
+      if (props.openOnFocus || store.getState().query.length > 0) {
         onInput({
           query: store.getState().query,
           store,
@@ -227,7 +227,7 @@ export function getPropGetters<TItem>({
           providedProps.inputElement ===
             props.environment.document.activeElement &&
           !store.getState().isOpen &&
-          props.openOnFocus
+          (props.openOnFocus || store.getState().query.length > 0)
         ) {
           onFocus();
         }

--- a/packages/autocomplete-core/src/propGetters.ts
+++ b/packages/autocomplete-core/src/propGetters.ts
@@ -117,18 +117,19 @@ export function getPropGetters<TItem>({
       onReset: event => {
         event.preventDefault();
 
-        onInput({
-          query: '',
-          store,
-          props,
-          setHighlightedIndex,
-          setQuery,
-          setSuggestions,
-          setIsOpen,
-          setStatus,
-          setContext,
-        });
-
+        if (props.openOnFocus) {
+          onInput({
+            query: '',
+            store,
+            props,
+            setHighlightedIndex,
+            setQuery,
+            setSuggestions,
+            setIsOpen,
+            setStatus,
+            setContext,
+          });
+        }
         store.send('reset', null);
 
         if (providedProps.inputElement) {

--- a/packages/autocomplete-core/src/propGetters.ts
+++ b/packages/autocomplete-core/src/propGetters.ts
@@ -117,19 +117,17 @@ export function getPropGetters<TItem>({
       onReset: event => {
         event.preventDefault();
 
-        if (props.minLength === 0) {
-          onInput({
-            query: '',
-            store,
-            props,
-            setHighlightedIndex,
-            setQuery,
-            setSuggestions,
-            setIsOpen,
-            setStatus,
-            setContext,
-          });
-        }
+        onInput({
+          query: '',
+          store,
+          props,
+          setHighlightedIndex,
+          setQuery,
+          setSuggestions,
+          setIsOpen,
+          setStatus,
+          setContext,
+        });
 
         store.send('reset', null);
 
@@ -143,9 +141,9 @@ export function getPropGetters<TItem>({
 
   const getInputProps: GetInputProps = providedProps => {
     function onFocus() {
-      // We want to trigger a query when `minLength` is reached because the
-      // dropdown should open with the current query.
-      if (store.getState().query.length >= props.minLength) {
+      // We want to trigger a query when `openOnFocus` is true
+      // because the dropdown should open with the current query.
+      if (props.openOnFocus) {
         onInput({
           query: store.getState().query,
           store,
@@ -228,7 +226,7 @@ export function getPropGetters<TItem>({
           providedProps.inputElement ===
             props.environment.document.activeElement &&
           !store.getState().isOpen &&
-          store.getState().query.length >= props.minLength
+          props.openOnFocus
         ) {
           onFocus();
         }

--- a/packages/autocomplete-core/src/stateReducer.ts
+++ b/packages/autocomplete-core/src/stateReducer.ts
@@ -103,8 +103,14 @@ export const stateReducer: Reducer = (action, state, props) => {
     case 'reset': {
       return {
         ...state,
-        highlightedIndex: null,
-        isOpen: false,
+        highlightedIndex:
+          // Since we open the menu on reset when openOnFocus=true
+          // we need to restore the highlighted index to the defaultHighlightedIndex. (DocSearch use-case)
+
+          // Since we close the menu when openOnFocus=false
+          // we lose track of the highlighted index. (Query-suggestions use-case)
+          props.openOnFocus === true ? props.defaultHighlightedIndex : null,
+        isOpen: props.openOnFocus, // @TODO: Check with UX team if we want to close the menu on reset.
         status: 'idle',
         statusContext: {},
         query: '',

--- a/packages/autocomplete-core/src/stateReducer.ts
+++ b/packages/autocomplete-core/src/stateReducer.ts
@@ -121,7 +121,7 @@ export const stateReducer: Reducer = (action, state, props) => {
       return {
         ...state,
         highlightedIndex: props.defaultHighlightedIndex,
-        isOpen: props.openOnFocus,
+        isOpen: props.openOnFocus || state.query.length > 0,
       };
     }
 

--- a/packages/autocomplete-core/src/stateReducer.ts
+++ b/packages/autocomplete-core/src/stateReducer.ts
@@ -115,7 +115,7 @@ export const stateReducer: Reducer = (action, state, props) => {
       return {
         ...state,
         highlightedIndex: props.defaultHighlightedIndex,
-        isOpen: state.query.length >= props.minLength,
+        isOpen: props.openOnFocus,
       };
     }
 

--- a/packages/autocomplete-core/src/types/api.ts
+++ b/packages/autocomplete-core/src/types/api.ts
@@ -168,11 +168,11 @@ export interface PublicAutocompleteOptions<TItem> {
    */
   showCompletion?: boolean;
   /**
-   * The minimum number of characters long the autocomplete opens.
+   * Whether to open the dropdown on focus.
    *
-   * @default 1
+   * @default false
    */
-  minLength?: number;
+  openOnFocus?: boolean;
   /**
    * The number of milliseconds that must elapse before the autocomplete
    * experience is stalled.
@@ -229,7 +229,7 @@ export interface AutocompleteOptions<TItem> {
   autoFocus: boolean;
   defaultHighlightedIndex: number | null;
   showCompletion: boolean;
-  minLength: number;
+  openOnFocus: boolean;
   stallThreshold: number;
   initialState: AutocompleteState<TItem>;
   getSources: GetSources<TItem>;

--- a/packages/autocomplete-core/src/types/api.ts
+++ b/packages/autocomplete-core/src/types/api.ts
@@ -168,7 +168,7 @@ export interface PublicAutocompleteOptions<TItem> {
    */
   showCompletion?: boolean;
   /**
-   * Whether to open the dropdown on focus.
+   * Whether to open the dropdown on focus when there's no query.
    *
    * @default false
    */

--- a/stories/react.stories.tsx
+++ b/stories/react.stories.tsx
@@ -242,4 +242,44 @@ storiesOf('React', module)
 
       return container;
     })
+  )
+  .add(
+    'Open on focus',
+    withPlayground(({ container, dropdownContainer }) => {
+      render(
+        <Autocomplete
+          placeholder="Search items…"
+          showCompletion={true}
+          dropdownContainer={dropdownContainer}
+          defaultHighlightedIndex={null}
+          openOnFocus={true}
+          getSources={() => {
+            return [
+              {
+                getInputValue({ suggestion }) {
+                  return suggestion.query;
+                },
+                getSuggestions({ query }) {
+                  return getAlgoliaHits({
+                    searchClient,
+                    queries: [
+                      {
+                        indexName: 'instant_search_demo_query_suggestions',
+                        query,
+                        params: {
+                          hitsPerPage: 4,
+                        },
+                      },
+                    ],
+                  });
+                },
+              },
+            ];
+          }}
+        />,
+        container
+      );
+
+      return container;
+    })
   );

--- a/stories/react.stories.tsx
+++ b/stories/react.stories.tsx
@@ -251,7 +251,7 @@ storiesOf('React', module)
           placeholder="Search items…"
           showCompletion={true}
           dropdownContainer={dropdownContainer}
-          defaultHighlightedIndex={null}
+          defaultHighlightedIndex={0}
           openOnFocus={true}
           getSources={() => {
             return [


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This PR adds `openOnFocus` and removes `minLength`.

[Preview ➡️](https://deploy-preview-31--autocomplete-experimental.netlify.com/stories/?path=/story/react--open-on-focus)