### PR TITLE
docs(example): avoid height 100%

### DIFF
--- a/examples/autocomplete.js/app.css
+++ b/examples/autocomplete.js/app.css
@@ -64,7 +64,6 @@ body {
   background: inherit;
   border: none;
   font: inherit;
-  height: 100%;
   outline: none;
   padding: 1rem;
   width: 100%;


### PR DESCRIPTION
Not sure if this is on every browser, but on safari it takes up full height like that

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

before | after
---|---
<img width="580" alt="Screenshot 2020-03-10 at 09 42 55" src="https://user-images.githubusercontent.com/6270048/76294876-f8bc9d00-62b3-11ea-8386-5dce5d67f4f2.png"> | <img width="791" alt="Screenshot 2020-03-10 at 09 46 17" src="https://user-images.githubusercontent.com/6270048/76294930-0a9e4000-62b4-11ea-86de-86a1f516eacd.png">



