### PR TITLE
Adds a query prop

### DIFF
--- a/packages/docsearch-react/src/DocSearch.tsx
+++ b/packages/docsearch-react/src/DocSearch.tsx
@@ -17,6 +17,7 @@ export interface DocSearchProps
   indexName: string;
   placeholder?: string;
   searchParameters?: any;
+  query?: string;
   transformItems?(items: DocSearchHit[]): DocSearchHit[];
   hitComponent?(props: {
     hit: DocSearchHit;

--- a/packages/docsearch-react/src/DocSearchModal.tsx
+++ b/packages/docsearch-react/src/DocSearchModal.tsx
@@ -39,6 +39,7 @@ export function DocSearchModal({
   resultsFooterComponent = () => null,
   navigator,
   initialScrollY = 0,
+  query,
 }: DocSearchModalProps) {
   const [state, setState] = React.useState<
     AutocompleteState<InternalDocSearchHit>
@@ -51,11 +52,13 @@ export function DocSearchModal({
   const searchBoxRef = React.useRef<HTMLDivElement | null>(null);
   const dropdownRef = React.useRef<HTMLDivElement | null>(null);
   const inputRef = React.useRef<HTMLInputElement | null>(null);
-  const snipetLength = React.useRef<number>(10);
+  const snippetLength = React.useRef<number>(10);
+
+  const defaultQueryText = query ? query : '';
   const initialQuery = React.useRef(
     typeof window !== 'undefined'
       ? window.getSelection()!.toString().slice(0, MAX_QUERY_SIZE)
-      : ''
+      : defaultQueryText
   ).current;
 
   const searchClient = useSearchClient(appId, apiKey);
@@ -166,13 +169,13 @@ export function DocSearchModal({
                     'url',
                   ],
                   attributesToSnippet: [
-                    `hierarchy.lvl1:${snipetLength.current}`,
-                    `hierarchy.lvl2:${snipetLength.current}`,
-                    `hierarchy.lvl3:${snipetLength.current}`,
-                    `hierarchy.lvl4:${snipetLength.current}`,
-                    `hierarchy.lvl5:${snipetLength.current}`,
-                    `hierarchy.lvl6:${snipetLength.current}`,
-                    `content:${snipetLength.current}`,
+                    `hierarchy.lvl1:${snippetLength.current}`,
+                    `hierarchy.lvl2:${snippetLength.current}`,
+                    `hierarchy.lvl3:${snippetLength.current}`,
+                    `hierarchy.lvl4:${snippetLength.current}`,
+                    `hierarchy.lvl5:${snippetLength.current}`,
+                    `hierarchy.lvl6:${snippetLength.current}`,
+                    `content:${snippetLength.current}`,
                   ],
                   snippetEllipsisText: '…',
                   highlightPreTag: '<mark>',
@@ -292,7 +295,7 @@ export function DocSearchModal({
     const isMobileMediaQuery = window.matchMedia('(max-width: 750px)');
 
     if (isMobileMediaQuery.matches) {
-      snipetLength.current = 5;
+      snippetLength.current = 5;
     }
   }, []);
 


### PR DESCRIPTION

**Summary**

I've been looking at integrating the react version of the docsearch into the TS website in lieu of https://github.com/algolia/docsearch/pull/955 in this PR https://github.com/microsoft/TypeScript-Website/pull/690 

The bug in the text to speech isn't present in the new version (the HTML is simpler, and contains the full text of each result )- which solves that issue, but I need to be able to pass an initial query into the modal, so that I can have someone type in the input and then send that off.

![2020-06-22 10-54-45 2020-06-22 10_56_18](https://user-images.githubusercontent.com/49038/85302565-4d58e200-b477-11ea-8c52-213c5d01be36.gif)

---

That said, I'm not too sure if this is the right way to do it vs all the `useX` functions that are around but at least it proves the concept