### PR TITLE
fix(docsearch): group search button elements in containers

### DIFF
--- a/packages/docsearch-css/src/button.css
+++ b/packages/docsearch-css/src/button.css
@@ -9,6 +9,7 @@
   display: flex;
   font-weight: 500;
   height: 36px;
+  justify-content: space-between;
   margin: 0 0 0 16px;
   padding: 0 8px;
   user-select: none;
@@ -23,6 +24,11 @@
   outline: none;
 }
 
+.DocSearch-Button-Container {
+  align-items: center;
+  display: flex;
+}
+
 .DocSearch-Search-Icon {
   stroke-width: 1.6;
 }
@@ -34,6 +40,10 @@
 .DocSearch-Button-Placeholder {
   font-size: 1rem;
   padding: 0 12px 0 6px;
+}
+
+.DocSearch-Button-Keys {
+  display: flex;
 }
 
 .DocSearch-Button-Key {

--- a/packages/docsearch-react/src/DocSearchButton.tsx
+++ b/packages/docsearch-react/src/DocSearchButton.tsx
@@ -41,13 +41,17 @@ export const DocSearchButton = React.forwardRef<
       {...props}
       ref={ref}
     >
-      <SearchIcon />
-      <span className="DocSearch-Button-Placeholder">Search</span>
+      <div className="DocSearch-Button-Container">
+        <SearchIcon />
+        <span className="DocSearch-Button-Placeholder">Search</span>
+      </div>
 
-      <span className="DocSearch-Button-Key">
-        {key === ACTION_KEY_DEFAULT ? <ControlKeyIcon /> : key}
-      </span>
-      <span className="DocSearch-Button-Key">K</span>
+      <div className="DocSearch-Button-Keys">
+        <span className="DocSearch-Button-Key">
+          {key === ACTION_KEY_DEFAULT ? <ControlKeyIcon /> : key}
+        </span>
+        <span className="DocSearch-Button-Key">K</span>
+      </div>
     </button>
   );
 });


### PR DESCRIPTION
This adds some markup in the search button to better customize its layout:

- Wrap the magnifier glass and the "Search" text in a container
- Wrap the keyboard shortcut in a container

This allows to more easily space them to the sides when the search box is longer than the default value:

![Preview](https://user-images.githubusercontent.com/6137112/91160718-0cc15300-e6ca-11ea-8830-f8fc4adbfd80.png)